### PR TITLE
Bump Docker Rust base image from 1.85 to 1.91

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} rust:1.85 as builder
+FROM --platform=${BUILDPLATFORM} rust:1.91 AS builder
 ARG TARGETPLATFORM
 ARG PROFILE=debug
 


### PR DESCRIPTION
Updated dependencies require rustc 1.86-1.91.1 (aws-sdk, diesel, time, etc.) which are incompatible with the pinned rust:1.85 image.

Changes:
- build.Dockerfile: rust:1.85 -> rust:1.91
- Fixed as -> AS casing warning