### PR TITLE
migrate API routes to /v1/ versioning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,33 +168,33 @@ pub fn configure_app(
                     .route("", web::get().to(routes::healthcheck::healthcheck)),
             )
             .service(
-                web::resource("/api/login")
+                web::resource("/api/v1/login")
                     .wrap(login_limiter.clone())
                     .route(web::post().to(routes::auth::login)),
             )
             .service(
-                web::resource("/api/logout")
+                web::resource("/api/v1/logout")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
                     .route(web::post().to(routes::auth::logout)),
             )
             .service(
-                web::resource("/api/registration")
+                web::resource("/api/v1/registration")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
                     .route(web::post().to(routes::users::add_user)),
             )
             .service(
-                web::resource("/api/email/verify")
+                web::resource("/api/v1/email/verify")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
                     .route(web::post().to(routes::auth::verify_email)),
             )
             .service(
-                web::resource("/api/password-reset/request")
+                web::resource("/api/v1/password-reset/request")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
@@ -203,7 +203,7 @@ pub fn configure_app(
                     ),
             )
             .service(
-                web::resource("/api/password-reset/complete")
+                web::resource("/api/v1/password-reset/complete")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
@@ -220,7 +220,7 @@ pub fn configure_app(
             )
             // public api
             .service(
-                web::scope("/api/public")
+                web::scope("/api/v1/public")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
@@ -259,7 +259,7 @@ pub fn configure_app(
             )
             // public user endpoints (unauthenticated)
             .service(
-                web::scope("/api/public")
+                web::scope("/api/v1/public")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
@@ -274,7 +274,7 @@ pub fn configure_app(
             )
             // OAuth endpoints (unauthenticated)
             .service(
-                web::scope("/api/auth/oauth")
+                web::scope("/api/v1/auth/oauth")
                     .wrap(api_rate_limiter(
                         &app_data.config.rate_limit.api_public,
                     ))
@@ -303,7 +303,7 @@ pub fn configure_app(
             )
             // authenticated api
             .service(
-                web::scope("/api")
+                web::scope("/api/v1")
                     .wrap(api_rate_limiter(&app_data.config.rate_limit.api))
                     .wrap(GrantsMiddleware::with_extractor(
                         routes::auth::extract,

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -116,7 +116,7 @@ pub async fn validate_token(
 
 #[utoipa::path(
     post,
-    path = "/api/login",
+    path = "/api/v1/login",
     tag = "auth",
     request_body = UserLogin,
     responses(
@@ -206,7 +206,7 @@ pub async fn login(
 
 #[utoipa::path(
     get,
-    path = "/api/sessions",
+    path = "/api/v1/sessions",
     tag = "auth",
     responses(
         (status = 200, description = "List of active sessions", body = Vec<SessionInfo>),
@@ -230,7 +230,7 @@ pub async fn list_sessions(
 
 #[utoipa::path(
     post,
-    path = "/api/logout",
+    path = "/api/v1/logout",
     tag = "auth",
     responses(
         (status = 200, description = "Logout successful - clears auth cookie"),
@@ -270,7 +270,7 @@ pub async fn logout(
 
 #[utoipa::path(
     delete,
-    path = "/api/sessions/{session_id}",
+    path = "/api/v1/sessions/{session_id}",
     tag = "auth",
     params(
         ("session_id" = String, Path, description = "Session ID to revoke"),
@@ -319,7 +319,7 @@ pub async fn revoke_session(
 
 #[utoipa::path(
     post,
-    path = "/api/sessions/revoke-others",
+    path = "/api/v1/sessions/revoke-others",
     tag = "auth",
     responses(
         (status = 200, description = "All other sessions revoked successfully"),
@@ -376,7 +376,7 @@ pub struct PasswordResetCompleteRequest {
 
 #[utoipa::path(
     post,
-    path = "/api/email/verify",
+    path = "/api/v1/email/verify",
     tag = "auth",
     request_body = VerifyEmailRequest,
     responses(
@@ -450,7 +450,7 @@ pub async fn verify_email(
 
 #[utoipa::path(
     post,
-    path = "/api/password-reset/request",
+    path = "/api/v1/password-reset/request",
     tag = "auth",
     request_body = PasswordResetRequest,
     responses(
@@ -516,7 +516,7 @@ pub async fn request_password_reset(
 
 #[utoipa::path(
     post,
-    path = "/api/password-reset/complete",
+    path = "/api/v1/password-reset/complete",
     tag = "auth",
     request_body = PasswordResetCompleteRequest,
     responses(

--- a/src/routes/command.rs
+++ b/src/routes/command.rs
@@ -30,7 +30,7 @@ pub struct RunCommandRequest {
 
 #[utoipa::path(
     post,
-    path = "/api/cmd",
+    path = "/api/v1/cmd",
     tag = "command",
     request_body = RunCommandRequest,
     responses(
@@ -277,7 +277,7 @@ pub async fn handle_run_command(
 
 #[utoipa::path(
     get,
-    path = "/api/cmd/{job_id}",
+    path = "/api/v1/cmd/{job_id}",
     tag = "command",
     params(
         ("job_id" = String, Path, description = "Job UUID"),
@@ -345,7 +345,7 @@ pub struct MetricsQuery {
 
 #[utoipa::path(
     get,
-    path = "/api/public/metrics/cmd",
+    path = "/api/v1/public/metrics/cmd",
     tag = "command",
     params(
         ("hours_since" = Option<i8>, Query, description = "Hours since to filter"),
@@ -386,7 +386,7 @@ pub async fn handle_get_job_metrics(
 
 #[utoipa::path(
     delete,
-    path = "/api/cmd/{job_id}",
+    path = "/api/v1/cmd/{job_id}",
     tag = "command",
     params(
         ("job_id" = String, Path, description = "Job UUID to abort"),

--- a/src/routes/misc.rs
+++ b/src/routes/misc.rs
@@ -4,7 +4,7 @@ use crate::get_build_info;
 
 #[utoipa::path(
     get,
-    path = "/api/public/build-info",
+    path = "/api/v1/public/build-info",
     tag = "public",
     responses(
         (status = 200, description = "Build information"),

--- a/src/routes/oauth.rs
+++ b/src/routes/oauth.rs
@@ -25,7 +25,7 @@ pub struct OAuthCallbackQuery {
 
 #[utoipa::path(
     get,
-    path = "/api/auth/oauth/github/login",
+    path = "/api/v1/auth/oauth/github/login",
     tag = "oauth",
     responses(
         (status = 307, description = "Redirects to GitHub OAuth"),
@@ -61,7 +61,7 @@ pub async fn github_login(
 
 #[utoipa::path(
     get,
-    path = "/api/auth/oauth/github/callback",
+    path = "/api/v1/auth/oauth/github/callback",
     tag = "oauth",
     responses(
         (status = 307, description = "Redirects to app root after successful login"),
@@ -136,7 +136,7 @@ pub async fn github_callback(
 
 #[utoipa::path(
     get,
-    path = "/api/auth/oauth/google/login",
+    path = "/api/v1/auth/oauth/google/login",
     tag = "oauth",
     responses(
         (status = 307, description = "Redirects to Google OAuth"),
@@ -172,7 +172,7 @@ pub async fn google_login(
 
 #[utoipa::path(
     get,
-    path = "/api/auth/oauth/google/callback",
+    path = "/api/v1/auth/oauth/google/callback",
     tag = "oauth",
     responses(
         (status = 307, description = "Redirects to app root after successful login"),

--- a/src/routes/pets.rs
+++ b/src/routes/pets.rs
@@ -27,7 +27,7 @@ pub(crate) struct PublicImageVariantPath {
 
 #[utoipa::path(
     get,
-    path = "/api/public/pets/traits",
+    path = "/api/v1/public/pets/traits",
     tag = "pets",
     responses(
         (status = 200, description = "List of personality traits", body = Vec<crate::models::pets::PersonalityTrait>),
@@ -49,7 +49,7 @@ pub async fn get_traits(
 
 #[utoipa::path(
     get,
-    path = "/api/public/pets/{pet_uuid}",
+    path = "/api/v1/public/pets/{pet_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -78,7 +78,7 @@ pub async fn get_public_pet(
 
 #[utoipa::path(
     post,
-    path = "/api/user/pets",
+    path = "/api/v1/user/pets",
     tag = "pets",
     request_body = crate::models::pets::CreatePet,
     responses(
@@ -110,7 +110,7 @@ pub async fn create_pet(
 
 #[utoipa::path(
     get,
-    path = "/api/user/pets",
+    path = "/api/v1/user/pets",
     tag = "pets",
     params(
         ("species" = Option<String>, Query, description = "Filter by species"),
@@ -152,7 +152,7 @@ pub async fn list_pets(
 
 #[utoipa::path(
     get,
-    path = "/api/user/pets/{pet_uuid}",
+    path = "/api/v1/user/pets/{pet_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -193,7 +193,7 @@ pub async fn get_pet(
 
 #[utoipa::path(
     patch,
-    path = "/api/user/pets/{pet_uuid}",
+    path = "/api/v1/user/pets/{pet_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -236,7 +236,7 @@ pub async fn update_pet(
 
 #[utoipa::path(
     delete,
-    path = "/api/user/pets/{pet_uuid}",
+    path = "/api/v1/user/pets/{pet_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -271,7 +271,7 @@ pub async fn delete_pet(
 
 #[utoipa::path(
     post,
-    path = "/api/user/pets/{pet_uuid}/images",
+    path = "/api/v1/user/pets/{pet_uuid}/images",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -378,7 +378,7 @@ pub async fn upload_pet_image(
 
 #[utoipa::path(
     get,
-    path = "/api/user/pets/{pet_uuid}/images",
+    path = "/api/v1/user/pets/{pet_uuid}/images",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -413,7 +413,7 @@ pub async fn list_pet_images(
 
 #[utoipa::path(
     delete,
-    path = "/api/user/pets/{pet_uuid}/images/{image_uuid}",
+    path = "/api/v1/user/pets/{pet_uuid}/images/{image_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -457,7 +457,7 @@ pub async fn delete_pet_image(
 
 #[utoipa::path(
     patch,
-    path = "/api/user/pets/{pet_uuid}/images/{image_uuid}",
+    path = "/api/v1/user/pets/{pet_uuid}/images/{image_uuid}",
     tag = "pets",
     params(
         ("pet_uuid" = crate::models::pets::PetUuid, Path, description = "Pet UUID"),
@@ -510,7 +510,7 @@ pub async fn set_primary_pet_image(
 
 #[utoipa::path(
     get,
-    path = "/api/public/pets/images/{image_uuid}",
+    path = "/api/v1/public/pets/images/{image_uuid}",
     tag = "pets",
     params(
         ("image_uuid" = uuid::Uuid, Path, description = "Image UUID"),
@@ -559,7 +559,7 @@ pub async fn get_public_pet_image(
 
 #[utoipa::path(
     get,
-    path = "/api/public/pets/images/{image_uuid}/{variant}",
+    path = "/api/v1/public/pets/images/{image_uuid}/{variant}",
     tag = "pets",
     params(
         ("image_uuid" = uuid::Uuid, Path, description = "Image UUID"),

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -19,7 +19,7 @@ use crate::{errors::DomainError, AppData};
 
 #[utoipa::path(
     get,
-    path = "/api/public/users/{user_id}",
+    path = "/api/v1/public/users/{user_id}",
     tag = "users",
     params(
         ("user_id" = String, Path, description = "User UUID"),
@@ -63,7 +63,7 @@ pub async fn get_user(
 
 #[utoipa::path(
     get,
-    path = "/api/admin/users",
+    path = "/api/v1/admin/users",
     tag = "users",
     params(
         ("page" = u16, Query, description = "Page number"),
@@ -102,7 +102,7 @@ pub async fn get_users(
 
 #[utoipa::path(
     post,
-    path = "/api/registration",
+    path = "/api/v1/registration",
     tag = "users",
     request_body = NewUser,
     responses(
@@ -188,7 +188,7 @@ pub struct UploadAvatarRequest {
 }
 #[utoipa::path(
     put,
-    path = "/api/avatars",
+    path = "/api/v1/avatars",
     tag = "users",
     request_body = UploadAvatarRequest,
     responses(
@@ -244,7 +244,7 @@ pub async fn upload_user_avatar(
 
 #[utoipa::path(
     delete,
-    path = "/api/avatars",
+    path = "/api/v1/avatars",
     tag = "users",
     responses(
         (status = 204, description = "Avatar deleted successfully"),
@@ -276,7 +276,7 @@ pub async fn delete_user_avatar(
 
 #[utoipa::path(
     get,
-    path = "/api/public/avatars/{user_id}",
+    path = "/api/v1/public/avatars/{user_id}",
     tag = "users",
     params(
         ("user_id" = String, Path, description = "User UUID"),
@@ -325,7 +325,7 @@ pub async fn get_user_avatar(
 
 #[utoipa::path(
     get,
-    path = "/api/user",
+    path = "/api/v1/user",
     tag = "users",
     responses(
         (status = 200, description = "User profile", body = User),
@@ -360,7 +360,7 @@ pub async fn get_my_profile(
 
 #[utoipa::path(
     patch,
-    path = "/api/user",
+    path = "/api/v1/user",
     tag = "users",
     request_body = UpdateUserProfile,
     responses(
@@ -444,7 +444,7 @@ pub async fn update_my_profile(
 
 #[utoipa::path(
     delete,
-    path = "/api/user",
+    path = "/api/v1/user",
     tag = "users",
     responses(
         (status = 200, description = "Account deleted successfully"),
@@ -498,7 +498,7 @@ pub async fn delete_my_account(
 
 #[utoipa::path(
     get,
-    path = "/api/public/profiles/{user_id}",
+    path = "/api/v1/public/profiles/{user_id}",
     tag = "users",
     params(
         ("user_id" = String, Path, description = "User UUID"),
@@ -529,7 +529,7 @@ pub async fn get_public_profile(
 
 #[utoipa::path(
     get,
-    path = "/api/user/profile",
+    path = "/api/v1/user/profile",
     tag = "users",
     responses(
         (status = 200, description = "Profile retrieved", body = PublicProfile),
@@ -570,7 +570,7 @@ pub async fn get_user_profile(
 
 #[utoipa::path(
     post,
-    path = "/api/user/profile",
+    path = "/api/v1/user/profile",
     tag = "users",
     request_body = CreateProfile,
     responses(
@@ -602,7 +602,7 @@ pub async fn create_user_profile(
 
 #[utoipa::path(
     patch,
-    path = "/api/user/profile",
+    path = "/api/v1/user/profile",
     tag = "users",
     request_body = UpdateProfile,
     responses(

--- a/src/services/oauth/github.rs
+++ b/src/services/oauth/github.rs
@@ -42,7 +42,7 @@ pub fn build_authorize_url(
         .append_pair("client_id", &config.client_id)
         .append_pair(
             "redirect_uri",
-            &format!("{base_url}/api/auth/oauth/github/callback"),
+            &format!("{base_url}/api/v1/auth/oauth/github/callback"),
         )
         .append_pair("scope", "read:user user:email")
         .append_pair("response_type", "code")
@@ -59,7 +59,7 @@ pub async fn exchange_code_for_token(
     base_url: &str,
 ) -> Result<GitHubTokenResponse, DomainError> {
     let client = reqwest::Client::new();
-    let redirect_uri = format!("{base_url}/api/auth/oauth/github/callback");
+    let redirect_uri = format!("{base_url}/api/v1/auth/oauth/github/callback");
     let token_url = format!("{base_url}{GITHUB_TOKEN_PATH}");
 
     let response = client

--- a/src/services/oauth/google.rs
+++ b/src/services/oauth/google.rs
@@ -45,7 +45,7 @@ pub fn build_authorize_url(
         .append_pair("client_id", &config.client_id)
         .append_pair(
             "redirect_uri",
-            &format!("{base_url}/api/auth/oauth/google/callback"),
+            &format!("{base_url}/api/v1/auth/oauth/google/callback"),
         )
         .append_pair("scope", "openid email profile")
         .append_pair("response_type", "code")
@@ -64,7 +64,7 @@ pub async fn exchange_code_for_token(
     base_url: &str,
 ) -> Result<GoogleTokenResponse, DomainError> {
     let client = reqwest::Client::new();
-    let redirect_uri = format!("{base_url}/api/auth/oauth/google/callback");
+    let redirect_uri = format!("{base_url}/api/v1/auth/oauth/google/callback");
     let token_url = format!("{base_url}{GOOGLE_TOKEN_PATH}");
 
     let response = client

--- a/tests/integration/auth.rs
+++ b/tests/integration/auth.rs
@@ -137,7 +137,7 @@ mod tests {
     ) -> (StatusCode, header::HeaderMap) {
         let resp = ctx
             .test_server
-            .post("/api/login")
+            .post("/api/v1/login")
             .append_header((header::CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
                 "username": username,
@@ -155,7 +155,7 @@ mod tests {
     async fn get_sessions(ctx: &TestContext, token: &str) -> StatusCode {
         let resp = ctx
             .test_server
-            .get("/api/sessions")
+            .get("/api/v1/sessions")
             .with_token(token)
             .send()
             .await

--- a/tests/integration/auth/email_verification.rs
+++ b/tests/integration/auth/email_verification.rs
@@ -12,7 +12,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .post("/api/email/verify")
+                .post("/api/v1/email/verify")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "token": "nonexistent_token_12345"
@@ -35,7 +35,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .post("/api/email/verify")
+                .post("/api/v1/email/verify")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "token": "some_random_token"
@@ -77,7 +77,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .post("/api/password-reset/request")
+                .post("/api/v1/password-reset/request")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "email": "reset_user@test.local"
@@ -100,7 +100,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .post("/api/password-reset/request")
+                .post("/api/v1/password-reset/request")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "email": "nonexistent@test.local"
@@ -120,7 +120,7 @@ mod tests {
             // Send a reset request first to ensure the token table has entries
             let _ = ctx
                 .test_server
-                .post("/api/password-reset/request")
+                .post("/api/v1/password-reset/request")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "email": "admin@example.com"
@@ -131,7 +131,7 @@ mod tests {
             // Test with invalid token - should return success (prevents email enumeration)
             let mut resp = ctx
                 .test_server
-                .post("/api/password-reset/complete")
+                .post("/api/v1/password-reset/complete")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "token": "nonexistent_reset_token",
@@ -182,7 +182,7 @@ mod tests {
             // Call the endpoint — should hit the expired path, not the "not found" path
             let resp = ctx
                 .test_server
-                .post("/api/password-reset/complete")
+                .post("/api/v1/password-reset/complete")
                 .append_header(("content-type", "application/json"))
                 .send_json(&serde_json::json!({
                     "token": token,

--- a/tests/integration/auth/oauth.rs
+++ b/tests/integration/auth/oauth.rs
@@ -28,7 +28,7 @@ mod tests {
 
         let response = ctx
             .client
-            .get(&format!("http://{}/api/auth/oauth/github/login", ctx.addr))
+            .get(&format!("http://{}/api/v1/auth/oauth/github/login", ctx.addr))
             .send()
             .await
             .unwrap();
@@ -124,7 +124,7 @@ mod tests {
 
         // Call callback
         let callback_url = format!(
-            "http://{}/api/auth/oauth/github/callback?code=test-auth-code&state={}",
+            "http://{}/api/v1/auth/oauth/github/callback?code=test-auth-code&state={}",
             ctx.addr, state
         );
         let response = ctx.client.get(&callback_url).send().await.unwrap();
@@ -147,7 +147,7 @@ mod tests {
 
         let mut response = ctx
             .test_server
-            .get("/api/auth/oauth/github/callback?code=test-code&state=invalid-state-xyz")
+            .get("/api/v1/auth/oauth/github/callback?code=test-code&state=invalid-state-xyz")
             .send()
             .await
             .unwrap();
@@ -169,7 +169,7 @@ mod tests {
 
         let mut response = ctx
             .test_server
-            .get("/api/auth/oauth/github/callback?error=access_denied&error_description=User+cancelled+authorization")
+            .get("/api/v1/auth/oauth/github/callback?error=access_denied&error_description=User+cancelled+authorization")
             .send()
             .await
             .unwrap();
@@ -194,7 +194,7 @@ mod tests {
 
         let response = ctx
             .client
-            .get(&format!("http://{}/api/auth/oauth/google/login", ctx.addr))
+            .get(&format!("http://{}/api/v1/auth/oauth/google/login", ctx.addr))
             .send()
             .await
             .unwrap();
@@ -255,7 +255,7 @@ mod tests {
         let _: () = redis.set_ex(&key, code_verifier, 300).await.unwrap();
 
         let callback_url = format!(
-            "http://{}/api/auth/oauth/google/callback?code=google-auth-code&state={}",
+            "http://{}/api/v1/auth/oauth/google/callback?code=google-auth-code&state={}",
             ctx.addr, state
         );
         let response = ctx.client.get(&callback_url).send().await.unwrap();
@@ -374,7 +374,7 @@ mod tests {
         let github_response = github_ctx
             .client
             .get(&format!(
-                "http://{}/api/auth/oauth/github/callback?code=gh-code&state=github-state",
+                "http://{}/api/v1/auth/oauth/github/callback?code=gh-code&state=github-state",
                 github_ctx.addr
             ))
             .send()
@@ -393,7 +393,7 @@ mod tests {
         let google_response = github_ctx
             .client
             .get(&format!(
-                "http://{}/api/auth/oauth/google/callback?code=google-code&state=google-state",
+                "http://{}/api/v1/auth/oauth/google/callback?code=google-code&state=google-state",
                 github_ctx.addr
             ))
             .send()
@@ -489,7 +489,7 @@ mod tests {
         let response = ctx
             .client
             .get(&format!(
-                "http://{}/api/auth/oauth/github/callback?code=new-code&state=new-user-state",
+                "http://{}/api/v1/auth/oauth/github/callback?code=new-code&state=new-user-state",
                 ctx.addr
             ))
             .send()
@@ -531,7 +531,7 @@ mod tests {
 
         let response = ctx
             .test_server
-            .get("/api/auth/oauth/github/login")
+            .get("/api/v1/auth/oauth/github/login")
             .send()
             .await
             .unwrap();
@@ -547,7 +547,7 @@ mod tests {
 
         let response = ctx
             .test_server
-            .get("/api/auth/oauth/google/login")
+            .get("/api/v1/auth/oauth/google/login")
             .send()
             .await
             .unwrap();
@@ -599,7 +599,7 @@ mod tests {
 
         let response = ctx
             .test_server
-            .get("/api/auth/oauth/github/callback?code=no-email-code&state=no-email-state")
+            .get("/api/v1/auth/oauth/github/callback?code=no-email-code&state=no-email-state")
             .send()
             .await
             .unwrap();
@@ -615,7 +615,7 @@ mod tests {
 
         let mut response = ctx
             .test_server
-            .get("/api/auth/oauth/google/callback?code=google-code&state=invalid-google-state")
+            .get("/api/v1/auth/oauth/google/callback?code=google-code&state=invalid-google-state")
             .send()
             .await
             .unwrap();
@@ -637,7 +637,7 @@ mod tests {
 
         let mut response = ctx
             .test_server
-            .get("/api/auth/oauth/google/callback?error=access_denied&error_description=User+cancelled")
+            .get("/api/v1/auth/oauth/google/callback?error=access_denied&error_description=User+cancelled")
             .send()
             .await
             .unwrap();

--- a/tests/integration/auth/oauth.rs
+++ b/tests/integration/auth/oauth.rs
@@ -28,7 +28,10 @@ mod tests {
 
         let response = ctx
             .client
-            .get(&format!("http://{}/api/v1/auth/oauth/github/login", ctx.addr))
+            .get(&format!(
+                "http://{}/api/v1/auth/oauth/github/login",
+                ctx.addr
+            ))
             .send()
             .await
             .unwrap();
@@ -194,7 +197,10 @@ mod tests {
 
         let response = ctx
             .client
-            .get(&format!("http://{}/api/v1/auth/oauth/google/login", ctx.addr))
+            .get(&format!(
+                "http://{}/api/v1/auth/oauth/google/login",
+                ctx.addr
+            ))
             .send()
             .await
             .unwrap();

--- a/tests/integration/auth/rate_limit.rs
+++ b/tests/integration/auth/rate_limit.rs
@@ -25,7 +25,7 @@ mod tests {
             for _ in 0..2 {
                 let resp = ctx
                     .test_server
-                    .get("/api/sessions")
+                    .get("/api/v1/sessions")
                     .with_token(&token)
                     .send()
                     .await
@@ -44,7 +44,7 @@ mod tests {
             // Send 3rd request which should be rate limited
             let resp = ctx
                 .test_server
-                .get("/api/sessions")
+                .get("/api/v1/sessions")
                 .with_token(&token)
                 .send()
                 .await
@@ -65,7 +65,7 @@ mod tests {
             // Try API request after window expiration
             let resp = ctx
                 .test_server
-                .get("/api/sessions")
+                .get("/api/v1/sessions")
                 .with_token(&token)
                 .send()
                 .await

--- a/tests/integration/auth/registration_verification_login.rs
+++ b/tests/integration/auth/registration_verification_login.rs
@@ -40,7 +40,7 @@ mod tests {
             // Step 3: Verify the email using the token
             let mut resp = ctx
                 .test_server
-                .post("/api/email/verify")
+                .post("/api/v1/email/verify")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "token": token
@@ -55,7 +55,7 @@ mod tests {
             // Step 4: Login with the verified account
             let resp = ctx
                 .test_server
-                .post("/api/login")
+                .post("/api/v1/login")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "username": username,
@@ -74,7 +74,7 @@ mod tests {
             // Step 6: Use the token to make a protected request
             let resp = ctx
                 .test_server
-                .get("/api/sessions")
+                .get("/api/v1/sessions")
                 .with_token(&auth_token)
                 .send()
                 .await
@@ -132,7 +132,7 @@ mod tests {
 
             // First registration should succeed
             let resp = client
-                .post(format!("http://{addr}/api/registration"))
+                .post(format!("http://{addr}/api/v1/registration"))
                 .insert_header(("content-type", "application/json"))
                 .send_body(format!(
                     r#"{{"username":"{username}","password":"{password}","email":"{email}"}}"#
@@ -143,7 +143,7 @@ mod tests {
 
             // Second registration with same email should fail
             let resp = client
-                .post(format!("http://{addr}/api/registration"))
+                .post(format!("http://{addr}/api/v1/registration"))
                 .insert_header(("content-type", "application/json"))
                 .send_body(format!(
                     r#"{{"username":"dupuser2","password":"{password}","email":"{email}"}}"#
@@ -215,7 +215,7 @@ mod tests {
             // Do NOT verify the email - attempt login anyway
             let resp = ctx
                 .test_server
-                .post("/api/login")
+                .post("/api/v1/login")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "username": username,
@@ -242,7 +242,7 @@ mod tests {
             // Try to verify with a non-existent token
             let mut resp = ctx
                 .test_server
-                .post("/api/email/verify")
+                .post("/api/v1/email/verify")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "token": "invalid_token_12345"
@@ -287,7 +287,7 @@ mod tests {
             // The token should be usable for verification
             let mut resp = ctx
                 .test_server
-                .post("/api/email/verify")
+                .post("/api/v1/email/verify")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "token": token

--- a/tests/integration/auth/session.rs
+++ b/tests/integration/auth/session.rs
@@ -31,7 +31,7 @@ mod tests {
         ) -> (StatusCode, Option<String>) {
             let resp = ctx
                 .test_server
-                .post("/api/login")
+                .post("/api/v1/login")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({
                     "username": common::DEFAULT_USER,

--- a/tests/integration/auth/session/session_renewal.rs
+++ b/tests/integration/auth/session/session_renewal.rs
@@ -42,7 +42,7 @@ mod tests {
             // Verify expiration
             let resp = ctx
                 .test_server
-                .get("/api/sessions")
+                .get("/api/v1/sessions")
                 .with_token(&token)
                 .send()
                 .await
@@ -141,7 +141,7 @@ mod tests {
             // Verify token has expired
             let resp = ctx
                 .test_server
-                .get("/api/sessions")
+                .get("/api/v1/sessions")
                 .with_token(&token)
                 .send()
                 .await
@@ -178,7 +178,7 @@ mod tests {
     async fn test_request(ctx: &TestContext, token: &str) -> HeaderMap {
         let resp = ctx
             .test_server
-            .get("/api/sessions")
+            .get("/api/v1/sessions")
             .with_token(token)
             .send()
             .await

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -638,7 +638,7 @@ pub async fn app_data(
                 .unwrap(),
             )
         },
-        swagger_path: "/api/swagger".to_string(),
+        swagger_path: "/api/v1/swagger".to_string(),
     });
     Ok(data)
 }
@@ -697,7 +697,7 @@ pub async fn get_token(
         .set_payload(format!(
             r#"{{"username":"{username}","password":"{password}"}}"#
         ))
-        .uri("/api/login")
+        .uri("/api/v1/login")
         .to_request();
     let resp: ServiceResponse<_> = test_app.call(req).await.unwrap();
     // Get the underlying HttpResponse
@@ -775,7 +775,7 @@ pub async fn get_http_token(
     client: &Client,
 ) -> anyhow::Result<String> {
     let resp = client
-        .post(format!("http://{addr}/api/login"))
+        .post(format!("http://{addr}/api/v1/login"))
         .insert_header((header::CONTENT_TYPE, "application/json"))
         .send_body(format!(
             r#"{{"username":"{username}","password":"{password}"}}"#
@@ -804,7 +804,7 @@ pub async fn create_http_user_with_email(
     client: &Client,
 ) -> anyhow::Result<()> {
     let mut resp = client
-        .post(format!("http://{addr}/api/registration"))
+        .post(format!("http://{addr}/api/v1/registration"))
         .insert_header(("content-type", "application/json"))
         .send_json(&serde_json::json!({
             "username": username,
@@ -981,7 +981,7 @@ impl TestContext {
     ) -> HashMap<Uuid, SessionInfo> {
         let mut resp = self
             .test_server
-            .get("/api/sessions")
+            .get("/api/v1/sessions")
             .with_token(token)
             .send()
             .await
@@ -994,7 +994,7 @@ impl TestContext {
     pub async fn delete_session(&self, session_id: Uuid, token: &str) {
         let resp = self
             .test_server
-            .delete(format!("/api/sessions/{}", session_id))
+            .delete(format!("/api/v1/sessions/{}", session_id))
             .with_token(token)
             .send()
             .await
@@ -1011,7 +1011,7 @@ impl TestContext {
     ) -> Vec<User> {
         let mut resp = self
             .test_server
-            .get(format!("/api/admin/users?page={page}&limit={limit}"))
+            .get(format!("/api/v1/admin/users?page={page}&limit={limit}"))
             .with_token(token)
             .send()
             .await

--- a/tests/integration/misc.rs
+++ b/tests/integration/misc.rs
@@ -20,7 +20,7 @@ mod tests {
         let ctx = common::TestContext::new(None).await;
         let mut resp = ctx
             .test_server
-            .get("/api/public/build-info")
+            .get("/api/v1/public/build-info")
             .send()
             .await
             .unwrap();
@@ -62,7 +62,7 @@ mod tests {
             };
             let mut resp = ctx
                 .test_server
-                .post("/api/cmd")
+                .post("/api/v1/cmd")
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .with_token(&token)
                 .send_body(r#"{"args":[]}"#)
@@ -78,7 +78,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .get(format!("/api/cmd/{job_id}"))
+                .get(format!("/api/v1/cmd/{job_id}"))
                 .with_token(&token)
                 .send()
                 .await

--- a/tests/integration/pet_images.rs
+++ b/tests/integration/pet_images.rs
@@ -418,7 +418,10 @@ mod pet_images_api {
 
         let resp = ctx
             .test_server
-            .patch(format!("/api/v1/user/pets/{}/images/{}", pet_uuid, image_uuid))
+            .patch(format!(
+                "/api/v1/user/pets/{}/images/{}",
+                pet_uuid, image_uuid
+            ))
             .with_token(&token)
             .append_header((
                 actix_web::http::header::CONTENT_TYPE,
@@ -575,7 +578,10 @@ mod pet_images_api {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/v1/public/pets/images/{}/thumbnail", image_uuid))
+            .get(format!(
+                "/api/v1/public/pets/images/{}/thumbnail",
+                image_uuid
+            ))
             .send()
             .await
             .unwrap();

--- a/tests/integration/pet_images.rs
+++ b/tests/integration/pet_images.rs
@@ -36,7 +36,7 @@ async fn send_upload_request(
     image_bytes: Vec<u8>,
     content_type: &str,
 ) -> (StatusCode, serde_json::Value) {
-    let url = format!("http://{addr}/api/user/pets/{}/images", pet_uuid);
+    let url = format!("http://{addr}/api/v1/user/pets/{}/images", pet_uuid);
     let mut resp = client
         .post(&url)
         .insert_header(("cookie", format!("X-AUTH-TOKEN={}", token)))
@@ -58,7 +58,7 @@ async fn create_pet(
 ) -> String {
     let mut resp = ctx
         .test_server
-        .post("/api/user/pets")
+        .post("/api/v1/user/pets")
         .with_token(token)
         .append_header((
             actix_web::http::header::CONTENT_TYPE,
@@ -229,7 +229,7 @@ mod pet_images_api {
             .unwrap();
 
         let url =
-            format!("http://{}/api/user/pets/{}/images", ctx.addr, pet_uuid);
+            format!("http://{}/api/v1/user/pets/{}/images", ctx.addr, pet_uuid);
         let resp = ctx
             .client
             .post(&url)
@@ -300,7 +300,7 @@ mod pet_images_api {
         // List images
         let mut resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}/images", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}/images", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -322,7 +322,7 @@ mod pet_images_api {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}/images", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}/images", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -368,7 +368,7 @@ mod pet_images_api {
         let resp = ctx
             .test_server
             .patch(format!(
-                "/api/user/pets/{}/images/{}",
+                "/api/v1/user/pets/{}/images/{}",
                 pet_uuid, image_uuid_2
             ))
             .with_token(&token)
@@ -384,7 +384,7 @@ mod pet_images_api {
         // List images and verify toggle
         let mut resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}/images", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}/images", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -418,7 +418,7 @@ mod pet_images_api {
 
         let resp = ctx
             .test_server
-            .patch(format!("/api/user/pets/{}/images/{}", pet_uuid, image_uuid))
+            .patch(format!("/api/v1/user/pets/{}/images/{}", pet_uuid, image_uuid))
             .with_token(&token)
             .append_header((
                 actix_web::http::header::CONTENT_TYPE,
@@ -454,7 +454,7 @@ mod pet_images_api {
         let resp = ctx
             .test_server
             .delete(format!(
-                "/api/user/pets/{}/images/{}",
+                "/api/v1/user/pets/{}/images/{}",
                 pet_uuid, image_uuid
             ))
             .with_token(&token)
@@ -466,7 +466,7 @@ mod pet_images_api {
         // Verify it's gone
         let mut resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}/images", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}/images", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -479,7 +479,7 @@ mod pet_images_api {
         let resp = ctx
             .test_server
             .delete(format!(
-                "/api/user/pets/{}/images/{}",
+                "/api/v1/user/pets/{}/images/{}",
                 pet_uuid, image_uuid
             ))
             .with_token(&token)
@@ -513,7 +513,7 @@ mod pet_images_api {
         let resp = ctx
             .test_server
             .delete(format!(
-                "/api/user/pets/{}/images/{}",
+                "/api/v1/user/pets/{}/images/{}",
                 pet_uuid, image_uuid
             ))
             .with_token(&token_b)
@@ -544,7 +544,7 @@ mod pet_images_api {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/public/pets/images/{}", image_uuid))
+            .get(format!("/api/v1/public/pets/images/{}", image_uuid))
             .send()
             .await
             .unwrap();
@@ -575,7 +575,7 @@ mod pet_images_api {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/public/pets/images/{}/thumbnail", image_uuid))
+            .get(format!("/api/v1/public/pets/images/{}/thumbnail", image_uuid))
             .send()
             .await
             .unwrap();
@@ -612,7 +612,7 @@ mod pet_images_api {
         let resp = ctx
             .test_server
             .get(format!(
-                "/api/public/pets/images/{}/invalid_variant",
+                "/api/v1/public/pets/images/{}/invalid_variant",
                 image_uuid
             ))
             .send()

--- a/tests/integration/pets.rs
+++ b/tests/integration/pets.rs
@@ -11,7 +11,7 @@ mod pet_profiles_api {
 
         let mut resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -47,7 +47,7 @@ mod pet_profiles_api {
         // Verify the pet was created in the database
         let get_resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -62,7 +62,7 @@ mod pet_profiles_api {
 
         let mut resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -87,7 +87,7 @@ mod pet_profiles_api {
 
         let resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -108,7 +108,7 @@ mod pet_profiles_api {
 
         let mut resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -134,7 +134,7 @@ mod pet_profiles_api {
         // Create a pet first
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -153,7 +153,7 @@ mod pet_profiles_api {
         // Get the pet
         let mut resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -172,7 +172,7 @@ mod pet_profiles_api {
 
         let resp = ctx
             .test_server
-            .get("/api/user/pets/00000000-0000-0000-0000-000000000000")
+            .get("/api/v1/user/pets/00000000-0000-0000-0000-000000000000")
             .with_token(&token)
             .send()
             .await
@@ -189,7 +189,7 @@ mod pet_profiles_api {
         // Owner A creates a pet
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token1)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -207,7 +207,7 @@ mod pet_profiles_api {
         // Owner B tries to get the pet
         let resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token2)
             .send()
             .await
@@ -222,7 +222,7 @@ mod pet_profiles_api {
 
         // Create multiple pets
         ctx.test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -234,7 +234,7 @@ mod pet_profiles_api {
             .unwrap();
 
         ctx.test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -246,7 +246,7 @@ mod pet_profiles_api {
             .unwrap();
 
         ctx.test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -260,7 +260,7 @@ mod pet_profiles_api {
         // List all pets
         let mut resp = ctx
             .test_server
-            .get("/api/user/pets")
+            .get("/api/v1/user/pets")
             .with_token(&token)
             .send()
             .await
@@ -272,7 +272,7 @@ mod pet_profiles_api {
         // Filter by species
         let mut resp = ctx
             .test_server
-            .get("/api/user/pets?species=dog")
+            .get("/api/v1/user/pets?species=dog")
             .with_token(&token)
             .send()
             .await
@@ -285,7 +285,7 @@ mod pet_profiles_api {
         // Filter by traits
         let mut resp = ctx
             .test_server
-            .get("/api/user/pets?traits=playful")
+            .get("/api/v1/user/pets?traits=playful")
             .with_token(&token)
             .send()
             .await
@@ -304,7 +304,7 @@ mod pet_profiles_api {
         // Create a pet
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -324,7 +324,7 @@ mod pet_profiles_api {
         // Partial update - only change name and weight
         let mut resp = ctx
             .test_server
-            .patch(format!("/api/user/pets/{}", pet_uuid))
+            .patch(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -349,7 +349,7 @@ mod pet_profiles_api {
         // Create a pet with breed
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -368,7 +368,7 @@ mod pet_profiles_api {
         // Clear the breed field
         let mut resp = ctx
             .test_server
-            .patch(format!("/api/user/pets/{}", pet_uuid))
+            .patch(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -390,7 +390,7 @@ mod pet_profiles_api {
         // Create a pet with traits
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -409,7 +409,7 @@ mod pet_profiles_api {
         // Replace traits
         let mut resp = ctx
             .test_server
-            .patch(format!("/api/user/pets/{}", pet_uuid))
+            .patch(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -440,7 +440,7 @@ mod pet_profiles_api {
         // Create a pet
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -458,7 +458,7 @@ mod pet_profiles_api {
         // Delete the pet
         let resp = ctx
             .test_server
-            .delete(format!("/api/user/pets/{}", pet_uuid))
+            .delete(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -468,7 +468,7 @@ mod pet_profiles_api {
         // Verify it's gone
         let resp = ctx
             .test_server
-            .get(format!("/api/user/pets/{}", pet_uuid))
+            .get(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token)
             .send()
             .await
@@ -485,7 +485,7 @@ mod pet_profiles_api {
         // Owner X creates a pet
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token1)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -503,7 +503,7 @@ mod pet_profiles_api {
         // Owner Y tries to delete the pet
         let resp = ctx
             .test_server
-            .delete(format!("/api/user/pets/{}", pet_uuid))
+            .delete(format!("/api/v1/user/pets/{}", pet_uuid))
             .with_token(&token2)
             .send()
             .await
@@ -517,7 +517,7 @@ mod pet_profiles_api {
 
         let mut resp = ctx
             .test_server
-            .get("/api/public/pets/traits")
+            .get("/api/v1/public/pets/traits")
             .send()
             .await
             .unwrap();
@@ -542,7 +542,7 @@ mod pet_profiles_api {
         // Create a pet
         let mut create_resp = ctx
             .test_server
-            .post("/api/user/pets")
+            .post("/api/v1/user/pets")
             .with_token(&token)
             .append_header((CONTENT_TYPE, "application/json"))
             .send_json(&serde_json::json!({
@@ -562,7 +562,7 @@ mod pet_profiles_api {
         // Get public view (no auth needed)
         let mut resp = ctx
             .test_server
-            .get(format!("/api/public/pets/{}", pet_uuid))
+            .get(format!("/api/v1/public/pets/{}", pet_uuid))
             .send()
             .await
             .unwrap();
@@ -580,7 +580,7 @@ mod pet_profiles_api {
 
         let resp = ctx
             .test_server
-            .get("/api/public/pets/00000000-0000-0000-0000-000000000000")
+            .get("/api/v1/public/pets/00000000-0000-0000-0000-000000000000")
             .send()
             .await
             .unwrap();
@@ -594,7 +594,7 @@ mod pet_profiles_api {
 
         let mut resp = ctx
             .test_server
-            .get("/api/user/pets")
+            .get("/api/v1/user/pets")
             .with_token(&token)
             .send()
             .await

--- a/tests/integration/role_enforcement.rs
+++ b/tests/integration/role_enforcement.rs
@@ -11,7 +11,7 @@ mod tests {
         use super::*;
 
         /// Verifies that non-admin users (RoleUser) get 403 on admin-only routes.
-        /// Registration via /api/registration assigns RoleUser by default
+        /// Registration via /api/v1/registration assigns RoleUser by default
         /// (insert_new_regular_user → insert_new_user with RoleEnum::RoleUser).
         #[actix_rt::test]
         async fn should_return_403_for_non_admin_on_post_cmd() {
@@ -36,10 +36,10 @@ mod tests {
             .await
             .unwrap();
 
-            // Try to POST /api/cmd (admin-only)
+            // Try to POST /api/v1/cmd (admin-only)
             let resp = ctx
                 .test_server
-                .post("/api/cmd")
+                .post("/api/v1/cmd")
                 .with_token(&token)
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({"args": ["test"]}))
@@ -74,11 +74,11 @@ mod tests {
             .await
             .unwrap();
 
-            // Try to GET /api/cmd/{job_id} (admin-only)
+            // Try to GET /api/v1/cmd/{job_id} (admin-only)
             let fake_job_id = Uuid::new_v4().to_string();
             let resp = ctx
                 .test_server
-                .get(format!("/api/cmd/{}", fake_job_id))
+                .get(format!("/api/v1/cmd/{}", fake_job_id))
                 .with_token(&token)
                 .send()
                 .await
@@ -112,11 +112,11 @@ mod tests {
             .await
             .unwrap();
 
-            // Try to DELETE /api/cmd/{job_id} (admin-only)
+            // Try to DELETE /api/v1/cmd/{job_id} (admin-only)
             let fake_job_id = Uuid::new_v4().to_string();
             let resp = ctx
                 .test_server
-                .delete(format!("/api/cmd/{}", fake_job_id))
+                .delete(format!("/api/v1/cmd/{}", fake_job_id))
                 .with_token(&token)
                 .send()
                 .await
@@ -146,10 +146,10 @@ mod tests {
             .await
             .unwrap();
 
-            // POST /api/cmd should NOT return 403 for admin
+            // POST /api/v1/cmd should NOT return 403 for admin
             let resp = ctx
                 .test_server
-                .post("/api/cmd")
+                .post("/api/v1/cmd")
                 .with_token(&admin_token)
                 .append_header((header::CONTENT_TYPE, "application/json"))
                 .send_json(&serde_json::json!({"args": ["test"]}))
@@ -158,11 +158,11 @@ mod tests {
 
             assert_ne!(resp.status(), StatusCode::FORBIDDEN);
 
-            // GET /api/cmd/{job_id} should NOT return 403 for admin
+            // GET /api/v1/cmd/{job_id} should NOT return 403 for admin
             let fake_job_id = Uuid::new_v4().to_string();
             let resp = ctx
                 .test_server
-                .get(format!("/api/cmd/{}", fake_job_id))
+                .get(format!("/api/v1/cmd/{}", fake_job_id))
                 .with_token(&admin_token)
                 .send()
                 .await
@@ -170,10 +170,10 @@ mod tests {
 
             assert_ne!(resp.status(), StatusCode::FORBIDDEN);
 
-            // DELETE /api/cmd/{job_id} should NOT return 403 for admin
+            // DELETE /api/v1/cmd/{job_id} should NOT return 403 for admin
             let resp = ctx
                 .test_server
-                .delete(format!("/api/cmd/{}", fake_job_id))
+                .delete(format!("/api/v1/cmd/{}", fake_job_id))
                 .with_token(&admin_token)
                 .send()
                 .await
@@ -218,10 +218,10 @@ mod tests {
             .await
             .unwrap();
 
-            // DELETE /api/user should succeed (200) for any authenticated user
+            // DELETE /api/v1/user should succeed (200) for any authenticated user
             let resp = ctx
                 .test_server
-                .get("/api/user")
+                .get("/api/v1/user")
                 .with_token(&token)
                 .send()
                 .await
@@ -261,7 +261,7 @@ mod tests {
 
             let resp = ctx
                 .test_server
-                .get("/api/admin/users?page=0&limit=10")
+                .get("/api/v1/admin/users?page=0&limit=10")
                 .with_token(&token)
                 .send()
                 .await
@@ -293,7 +293,7 @@ mod tests {
 
             let resp = ctx
                 .test_server
-                .get("/api/admin/users?q=test&page=0&limit=10")
+                .get("/api/v1/admin/users?q=test&page=0&limit=10")
                 .with_token(&token)
                 .send()
                 .await
@@ -325,7 +325,7 @@ mod tests {
 
             let resp = ctx
                 .test_server
-                .get("/api/admin/users/55")
+                .get("/api/v1/admin/users/55")
                 .with_token(&token)
                 .send()
                 .await
@@ -349,7 +349,7 @@ mod tests {
 
             let resp = ctx
                 .test_server
-                .get("/api/admin/users")
+                .get("/api/v1/admin/users")
                 .with_token(&admin_token)
                 .send()
                 .await
@@ -375,7 +375,7 @@ mod tests {
 
             let resp = ctx
                 .test_server
-                .get("/api/admin/users?q=test")
+                .get("/api/v1/admin/users?q=test")
                 .with_token(&admin_token)
                 .send()
                 .await

--- a/tests/integration/users.rs
+++ b/tests/integration/users.rs
@@ -37,7 +37,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .get("/api/admin/users?page=0&limit=2")
+                .get("/api/v1/admin/users?page=0&limit=2")
                 .with_token(&token)
                 .send()
                 .await
@@ -83,7 +83,7 @@ mod tests {
             // First page with 10 users
             let mut resp = ctx
                 .test_server
-                .get("/api/admin/users?page=0&limit=10")
+                .get("/api/v1/admin/users?page=0&limit=10")
                 .with_token(&token)
                 .send()
                 .await
@@ -95,7 +95,7 @@ mod tests {
             // Second page with > 1 user
             let mut resp = ctx
                 .test_server
-                .get("/api/admin/users?page=1&limit=10")
+                .get("/api/v1/admin/users?page=1&limit=10")
                 .with_token(&token)
                 .send()
                 .await
@@ -126,7 +126,7 @@ mod tests {
 
             let mut resp = ctx
                 .test_server
-                .get(format!("/api/admin/users/{}", non_existent_uuid))
+                .get(format!("/api/v1/admin/users/{}", non_existent_uuid))
                 .with_token(&token)
                 .send()
                 .await
@@ -157,7 +157,7 @@ mod tests {
 
                 let mut resp = ctx
                     .test_server
-                    .get("/api/user/profile")
+                    .get("/api/v1/user/profile")
                     .with_token(&token)
                     .send()
                     .await
@@ -181,7 +181,7 @@ mod tests {
 
                 let mut resp = ctx
                     .test_server
-                    .post("/api/user/profile")
+                    .post("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -206,7 +206,7 @@ mod tests {
 
                 let mut get_resp = ctx
                     .test_server
-                    .get("/api/user/profile")
+                    .get("/api/v1/user/profile")
                     .with_token(&token)
                     .send()
                     .await
@@ -225,7 +225,7 @@ mod tests {
                     register_and_login(&ctx, "partialupdate", "test123").await;
 
                 ctx.test_server
-                    .post("/api/user/profile")
+                    .post("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -241,7 +241,7 @@ mod tests {
 
                 let mut resp = ctx
                     .test_server
-                    .patch("/api/user/profile")
+                    .patch("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -267,7 +267,7 @@ mod tests {
                     register_and_login(&ctx, "clearfield", "test123").await;
 
                 ctx.test_server
-                    .post("/api/user/profile")
+                    .post("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -283,7 +283,7 @@ mod tests {
 
                 let mut resp = ctx
                     .test_server
-                    .patch("/api/user/profile")
+                    .patch("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -322,7 +322,7 @@ mod tests {
 
                 let resp = ctx
                     .test_server
-                    .get(format!("/api/public/profiles/{}", user_uuid))
+                    .get(format!("/api/v1/public/profiles/{}", user_uuid))
                     .with_token(&admin_token)
                     .send()
                     .await
@@ -338,7 +338,7 @@ mod tests {
                     register_and_login(&ctx, "pubprofile", "test123").await;
 
                 ctx.test_server
-                    .post("/api/user/profile")
+                    .post("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
@@ -372,7 +372,7 @@ mod tests {
 
                 let mut resp = ctx
                     .test_server
-                    .get(format!("/api/public/profiles/{}", user_uuid))
+                    .get(format!("/api/v1/public/profiles/{}", user_uuid))
                     .with_token(&admin_token)
                     .send()
                     .await
@@ -390,7 +390,7 @@ mod tests {
 
                 let resp = ctx
                     .test_server
-                    .get("/api/user/profile")
+                    .get("/api/v1/user/profile")
                     .send()
                     .await
                     .unwrap();
@@ -404,7 +404,7 @@ mod tests {
 
                 let resp = ctx
                     .test_server
-                    .patch("/api/user/profile")
+                    .patch("/api/v1/user/profile")
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({
                         "bio": "test"
@@ -425,7 +425,7 @@ mod tests {
 
                 let resp = ctx
                     .test_server
-                    .post("/api/user/profile")
+                    .post("/api/v1/user/profile")
                     .with_token(&token)
                     .append_header((CONTENT_TYPE, "application/json"))
                     .send_json(&serde_json::json!({

--- a/tests/integration/ws.rs
+++ b/tests/integration/ws.rs
@@ -152,7 +152,7 @@ mod tests {
 
         let mut resp = ctx
             .test_server
-            .post("/api/cmd")
+            .post("/api/v1/cmd")
             .append_header((header::CONTENT_TYPE, "application/json"))
             .with_token(&token)
             .send_body(r#"{"args":["arg1", "arg2"]}"#)
@@ -211,7 +211,7 @@ mod tests {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/cmd/{job_id}"))
+            .get(format!("/api/v1/cmd/{job_id}"))
             .append_header((header::CONTENT_TYPE, "application/json"))
             .with_token(&token)
             .send()
@@ -256,7 +256,7 @@ mod tests {
 
         let mut resp = ctx
             .test_server
-            .post("/api/cmd")
+            .post("/api/v1/cmd")
             .append_header((header::CONTENT_TYPE, "application/json"))
             .with_token(&token)
             .send_body(r#"{"args":[]}"#)
@@ -277,7 +277,7 @@ mod tests {
 
         let resp = ctx
             .test_server
-            .delete(format!("/api/cmd/{job_id}"))
+            .delete(format!("/api/v1/cmd/{job_id}"))
             .with_token(&token)
             .send()
             .await
@@ -289,7 +289,7 @@ mod tests {
 
         let mut resp = ctx
             .test_server
-            .get(format!("/api/cmd/{job_id}"))
+            .get(format!("/api/v1/cmd/{job_id}"))
             .with_token(&token)
             .send()
             .await


### PR DESCRIPTION
## Changes

- Add  prefix to all app API routes (auth, users, pets, oauth, command, misc)
- Update integration tests to use  paths
- Fix OAuth redirect URIs to include  in callback paths
- Fix mailpit client double  paths in test helpers

## Verification

All 90 integration tests pass (0 failed, 4 ignored WebSocket tests).